### PR TITLE
fix(header): sort headers by name to get consistent test results

### DIFF
--- a/http/header.go
+++ b/http/header.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"io"
+	"sort"
 	"strconv"
 )
 
@@ -81,9 +82,11 @@ func (h Header) Write(w io.Writer) error {
 		ws = stringWriter{w}
 	}
 
-	for key, value := range h {
+	sorted := h.getSortedHeadersByName()
+
+	for _, key := range sorted {
 		// we want all headers "as-is"
-		s := key + ": " + value + "\r\n"
+		s := key + ": " + h[key] + "\r\n"
 		if _, err := ws.WriteString(s); err != nil {
 			return err
 		}
@@ -95,9 +98,11 @@ func (h Header) Write(w io.Writer) error {
 
 // WriteBytes writes a header in a ByteWriter.
 func (h Header) WriteBytes(b *bytes.Buffer) error {
-	for key, value := range h {
+	sorted := h.getSortedHeadersByName()
+
+	for _, key := range sorted {
 		// we want all headers "as-is"
-		s := key + ": " + value + "\r\n"
+		s := key + ": " + h[key] + "\r\n"
 		if _, err := b.Write([]byte(s)); err != nil {
 			return err
 		}
@@ -119,4 +124,16 @@ func (h Header) Clone() Header {
 	}
 
 	return clone
+}
+
+// sortHeadersByName gets headers sorted by name
+// This way the output is predictable, for tests
+func (h Header) getSortedHeadersByName() []string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return keys
 }

--- a/http/header_test.go
+++ b/http/header_test.go
@@ -23,7 +23,7 @@ var headerWriteTests = []struct {
 			"Content-Type":   "text/html; charset=UTF-8",
 			"Content-Length": "0",
 		},
-		"Content-Type: text/html; charset=UTF-8\r\nContent-Length: 0\r\n",
+		"Content-Length: 0\r\nContent-Type: text/html; charset=UTF-8\r\n",
 	},
 	{
 		Header{
@@ -37,7 +37,7 @@ var headerWriteTests = []struct {
 			"Content-Length":   "0",
 			"Content-Encoding": "gzip",
 		},
-		"Expires: -1\r\nContent-Length: 0\r\nContent-Encoding: gzip\r\n",
+		"Content-Encoding: gzip\r\nContent-Length: 0\r\nExpires: -1\r\n",
 	},
 	{
 		Header{


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Testing sometimes showed in different order. So we sort headers now before writing.