### PR TITLE
feat(quiet): be real quiet on output

### DIFF
--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -104,8 +104,14 @@ func TestRun(t *testing.T) {
 		}
 	})
 
-	t.Run("execute only test 008 and execute all", func(t *testing.T) {
+	t.Run("execute only test 008 but exclude all", func(t *testing.T) {
 		if res := Run("008", "*", false, false, tests); !res {
+			t.Fatalf("Oops, test run failed!")
+		}
+	})
+
+	t.Run("execute only test 008 but exclude all", func(t *testing.T) {
+		if res := Run("*", "010", false, false, tests); !res {
 			t.Fatalf("Oops, test run failed!")
 		}
 	})

--- a/runner/stats.go
+++ b/runner/stats.go
@@ -26,14 +26,22 @@ func addResultToStats(result bool, title string, stats *TestStats) {
 	}
 }
 
-func printSummary(stats TestStats) {
-	emoji.Printf(":plus:run %d total tests in %s\n", stats.Run, stats.RunTime)
-	emoji.Printf(":next_track_button:skept %d tests\n", stats.Skipped)
-	if stats.Failed == 0 && stats.Run > 0 {
-		emoji.Println(":tada:All tests successful!")
-		os.Exit(0)
-	} else if stats.Failed > 0 {
-		emoji.Printf(":minus:%d test(s) failed to run: %+q\n", stats.Failed, stats.FailedTests)
-		os.Exit(1)
+func printSummary(quiet bool, stats TestStats) {
+	if !quiet {
+		emoji.Printf(":plus:run %d total tests in %s\n", stats.Run, stats.RunTime)
+		emoji.Printf(":next_track_button: skept %d tests\n", stats.Skipped)
+		if stats.Failed == 0 && stats.Run > 0 {
+			emoji.Println(":tada:All tests successful!")
+			os.Exit(0)
+		} else if stats.Failed > 0 {
+			emoji.Printf(":minus:%d test(s) failed to run: %+q\n", stats.Failed, stats.FailedTests)
+			os.Exit(1)
+		}
+	} else { // just exit with proper status code
+		if stats.Failed == 0 && stats.Run > 0 {
+			os.Exit(0)
+		} else if stats.Failed > 0 {
+			os.Exit(1)
+		}
 	}
 }


### PR DESCRIPTION
Solves #7.

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Now when running with `--quiet`, what you get is just the information about the config file used, and exit codes.

Exit code `0` means all tests good, and `1` test failed with error.