### PR TITLE
Fix nginx time comparision

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ logtype:
   timeformat: '%a %b %d %H:%M:%S.%f %Y'
 ```
 
+For nginx, as logs will be to the second, you need to add the amount of time you want to truncate to. This will for example discard anything less than one second:
+
 ```yaml
 ---
 logfile: '../coreruleset/tests/logs/modsec3-nginx/nginx/error.log'
@@ -53,6 +55,7 @@ logtype:
   name: 'nginx'
   timeregex:  '(\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2})'
   timeformat: 'YYYY/MM/DD HH:mm:ss'
+  timetruncate: 1s
 ```
 
 If your webserver uses a different time format, please [create an issue](https://github.com/fzipi/go-ftw/issues/new/choose) and we can extend the documentation to cover it.

--- a/check/base.go
+++ b/check/base.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fzipi/go-ftw/config"
 	"github.com/fzipi/go-ftw/test"
 	"github.com/fzipi/go-ftw/waflog"
+	"github.com/rs/zerolog/log"
 )
 
 // FTWCheck is the base struct for checks
@@ -18,15 +19,17 @@ type FTWCheck struct {
 func NewCheck(c *config.FTWConfiguration) *FTWCheck {
 	check := &FTWCheck{
 		log: &waflog.FTWLogLines{
-			FileName:   c.LogFile,
-			TimeRegex:  c.LogType.TimeRegex,
-			TimeFormat: c.LogType.TimeFormat,
-			Since:      time.Now(),
-			Until:      time.Now(),
+			FileName:     c.LogFile,
+			TimeRegex:    c.LogType.TimeRegex,
+			TimeFormat:   c.LogType.TimeFormat,
+			Since:        time.Now(),
+			Until:        time.Now(),
+			TimeTruncate: c.LogType.TimeTruncate,
 		},
 		expected: &test.Output{},
 	}
 
+	log.Trace().Msgf("check/base: truncate set to %s", check.log.TimeTruncate)
 	return check
 }
 

--- a/check/base_test.go
+++ b/check/base_test.go
@@ -1,5 +1,12 @@
 package check
 
+import (
+	"testing"
+	"time"
+
+	"github.com/fzipi/go-ftw/config"
+)
+
 var yamlApacheConfig = `
 ---
 logfile: 'tests/logs/modsec2-apache/apache2/error.log'
@@ -16,4 +23,15 @@ logtype:
   name: 'nginx'
   timeregex:  '(\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2})'
   timeformat: 'YYYY/MM/DD HH:mm:ss'
+  timetruncate: 1s
 `
+
+func TestNewCheck(t *testing.T) {
+	config.ImportFromString(yamlNginxConfig)
+
+	c := NewCheck(config.FTWConfig)
+
+	if c.log.TimeTruncate != time.Second {
+		t.Errorf("Failed")
+	}
+}

--- a/check/logs.go
+++ b/check/logs.go
@@ -12,6 +12,7 @@ func (c *FTWCheck) AssertNoLogContains() bool {
 
 // AssertLogContains returns true when the logs contain the string
 func (c *FTWCheck) AssertLogContains() bool {
+	log.Trace().Msgf("ftw/check: check will truncate at %s", c.log.TimeTruncate)
 	if c.expected.LogContains != "" {
 		log.Debug().Msgf("ftw/check: log contains? -> %s", c.expected.LogContains)
 		return c.log.Contains(c.expected.LogContains)

--- a/config/config.go
+++ b/config/config.go
@@ -1,17 +1,24 @@
 package config
 
+import (
+	"time"
+)
+
 // FTWConfig is being exported to be used across the app
 var FTWConfig *FTWConfiguration
 
 // FTWConfiguration FTW global Configuration
 type FTWConfiguration struct {
-	LogFile string     `yaml:"logfile"`
-	LogType FTWLogType `yaml:"logtype"`
+	LogFile string
+	LogType FTWLogType
 }
 
 // FTWLogType log readers must implement this one
+// TimeTruncate is a string that represents a golang time, e.g. 'time.Microsecond', 'time.Second', etc.
+// It will be used when comparing times to match logs
 type FTWLogType struct {
-	Name       string `yaml:"name"`
-	TimeRegex  string `yaml:"timeregex"`
-	TimeFormat string `yaml:"timeformat"`
+	Name         string
+	TimeRegex    string
+	TimeFormat   string
+	TimeTruncate time.Duration
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/fzipi/go-ftw/utils"
 )
@@ -25,6 +27,16 @@ logtype:
   timeformat: 'ddd MMM DD HH:mm:ss.S YYYY'
 `
 
+var yamlTruncateConfig = `
+---
+logfile: 'tests/logs/modsec3-nginx/nginx/error.log'
+logtype:
+  name: nginx
+  timetruncate:  1s
+  timeformat: 'ddd MMM DD HH:mm:ss'
+
+`
+
 var jsonConfig = `
 {"test": "type"}
 `
@@ -45,13 +57,13 @@ func TestInitConfig(t *testing.T) {
 
 func TestInitBadFileConfig(t *testing.T) {
 	filename, _ := utils.CreateTempFileWithContent(jsonConfig, "test-*.yaml")
-
+	defer os.Remove(filename)
 	Init(filename)
 }
 
 func TestInitBadConfig(t *testing.T) {
 	filename, _ := utils.CreateTempFileWithContent(yamlBadConfig, "test-*.yaml")
-
+	defer os.Remove(filename)
 	Init(filename)
 
 	if FTWConfig == nil {
@@ -78,6 +90,24 @@ func TestImportConfig(t *testing.T) {
 	}
 
 	if FTWConfig.LogType.TimeFormat != "ddd MMM DD HH:mm:ss.S YYYY" {
+		t.Errorf("Failed !")
+	}
+}
+
+func TestTimeTruncateConfig(t *testing.T) {
+	filename, _ := utils.CreateTempFileWithContent(yamlTruncateConfig, "test-*.yaml")
+	defer os.Remove(filename)
+	Init(filename)
+
+	if FTWConfig.LogType.Name != "nginx" {
+		t.Errorf("Failed !")
+	}
+
+	if FTWConfig.LogType.TimeFormat != "ddd MMM DD HH:mm:ss" {
+		t.Errorf("Failed !")
+	}
+
+	if FTWConfig.LogType.TimeTruncate != time.Second {
 		t.Errorf("Failed !")
 	}
 }

--- a/config/init.go
+++ b/config/init.go
@@ -31,6 +31,11 @@ func Init(cfgFile string) {
 	if err != nil {
 		log.Fatal().Msgf("ftw/config: fatal error decoding config: %s", err.Error())
 	}
+	if duration := viper.GetDuration("logtype.timetruncate"); duration != 0 {
+		log.Info().Msgf("ftw/config: will truncate logs to %s", duration)
+	} else {
+		log.Info().Msgf("ftw/config: no duration found")
+	}
 }
 
 // ImportFromString initializes the configuration from a yaml formatted string. Useful for testing.

--- a/waflog/base.go
+++ b/waflog/base.go
@@ -11,6 +11,9 @@ type FTWLogLines struct {
 	TimeRegex string
 	// Gostradamus time format, e.g. 'ddd MMM DD HH:mm:ss.S YYYY'
 	TimeFormat string
-	Since      time.Time
-	Until      time.Time
+	// Truncate time to this time.Duration. Example is nginx logs will be up to the second,
+	// so you want to truncate using '1s'.
+	TimeTruncate time.Duration
+	Since        time.Time
+	Until        time.Time
 }


### PR DESCRIPTION
ModSecurity logs in nginx will be without microsecond, so we need to compare the same times when reading logs. Adding `timetruncate` allows you to do exactly that.