### PR TITLE
fix(check): print error about failing files now

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ Global Flags:
 
 Then run all tests (slightly modified, see [here](https://gist.github.com/fzipi/b9e22b3834a5fa32970878c72775d41e)) in the ModSecurity Core Rule set using:
 
+`ftw check -d tests -t`
+
+If you see errors like these:
+```
+> ./ftw run -d tests
+1:33PM INF Using config file: .ftw
+1:33PM INF ftw/config: no duration found
+🛠️  Starting tests!
+1:33PM ERR yaml: unmarshal errors:
+  line 44: cannot unmarshal !!int `400` into []int
+  line 98: cannot unmarshal !!int `400` into []int
+  line 229: cannot unmarshal !!int `400` into []int
+```
+
+You need to apply the patch above. Then you can run your tests using:
+
 `ftw run -d tests -t`
 
 And the result should be similar to:

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/fzipi/go-ftw/test"
+	"github.com/rs/zerolog/log"
 
 	"github.com/kyokomi/emoji"
 	"github.com/spf13/cobra"
@@ -26,10 +28,16 @@ func init() {
 }
 
 func checkFiles(dir string) {
-	files := fmt.Sprintf("%s/**/*.y[a]ml", dir)
+	var exit int
+	files := fmt.Sprintf("%s/**/*.yaml", dir)
+	log.Debug().Msgf("ftw/check: checking files using glob pattern: %s", files)
 	tests, err := test.GetTestsFromFiles(files)
 	if err != nil {
-		emoji.Printf("ftw: :red_cross: oops, found %s\n", err.Error())
+		emoji.Printf("ftw/check: :collision: oops, found %s\n", err.Error())
+		exit = 1
+	} else {
+		emoji.Printf("ftw/check: checked %d files, everything looks good!\n", len(tests))
+		exit = 0
 	}
-	emoji.Printf("ftw: checked %d files, everything looks good!\n", len(tests))
+	os.Exit(exit)
 }

--- a/test/files.go
+++ b/test/files.go
@@ -14,18 +14,23 @@ func GetTestsFromFiles(globPattern string) ([]FTWTest, error) {
 	var tests []FTWTest
 	var err error
 
-	testFiles, _ := filepath.Glob(globPattern)
+	testFiles, err := filepath.Glob(globPattern)
+
+	if err != nil {
+		log.Info().Msgf("ftw/test: error getting test files from %s", globPattern)
+		return tests, err
+	}
 
 	for _, test := range testFiles {
 		t, err := readTest(test)
 		if err != nil {
-			break
-		} else {
-			tests = append(tests, *t)
+			log.Debug().Msgf("ftw/test: error reading %s file. Is it patched?", test)
+			return tests, err
 		}
+		tests = append(tests, *t)
 	}
 
-	return tests, err
+	return tests, nil
 }
 
 func readTest(filename string) (t *FTWTest, err error) {

--- a/test/files_test.go
+++ b/test/files_test.go
@@ -65,7 +65,7 @@ func TestGetFromBadYAML(t *testing.T) {
 	filename, _ := utils.CreateTempFileWithContent(wrongYamlTest, "test-yaml-*")
 	_, err := GetTestsFromFiles(filename)
 
-	if err != nil {
+	if err == nil {
 		t.Fatalf("Error!")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Print failed file in check mode.