### PR TITLE
feat(tests): add test result overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ And the result should be similar to:
 ```
 Happy testing!
 
-## Additional features implemented already
+## Additional features
 
 You can add functions to your tests, to simplify bulk writing, or even read values from the environment while executing. This is because `data:` sections in tests will be parse for Go [text/template](https://golang.org/pkg/text/template/) additional syntax, and with the power of additional [Sprig functions](https://masterminds.github.io/sprig/).
 
@@ -171,6 +171,35 @@ data: 'username=fzipi
 ```
 
 Other interesting functions you can use are: `randBytes`, `htpasswd`, `encryptAES`, etc.
+
+## Overriding test results
+
+Sometimes you have tests that work well in some platform combination, e.g. Apache + modsecurity2, but fail in other, e.g. Nginx + modsecurity3. Taking that into account, you can override test results using the `testoverride` config param. The test will be run, but the _result_ would be overriden, and your comment will be printed out.
+
+Example:
+
+```yaml
+...
+testoverride:
+  ignore:
+    # text comes from our friends at https://github.com/digitalwave/ftwrunner
+    '941190-3': 'known MSC bug - PR #2023 (Cookie without value)'
+    '941330-1': 'know MSC bug - #2148 (double escape)'
+    '942480-2': 'known MSC bug - PR #2023 (Cookie without value)'
+    '944100-11': 'known MSC bug - PR #2045, ISSUE #2146'
+  forcefail:
+    '123456-01': 'I want this test to fail, even if passing'
+  forcepass:
+    '123456-02': 'This test will always pass'
+```
+
+You can combine any of `ignore`, `forcefail` and `forcepass` to make it work for you.
+
+## Truncating logs
+
+Log files can get really big. Searching patterns are performed using reverse text search in the file. Because the test tool is *really* fast, we sometimes see failures in nginx depending on how fast the tests are performed, mainly because log times in nginx are truncated to one second.
+
+To overcome this, you can use the new config value `logtruncate: True`. This will, as it says, call _truncate_ on the file, actively modifying it between each test. You will need permissions to write the logfile, implying you might need to call the go-ftw binary using sudo.
 
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ffzipi%2Fgo-ftw.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Ffzipi%2Fgo-ftw?ref=badge_large)

--- a/check/base.go
+++ b/check/base.go
@@ -9,10 +9,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// FTWCheck is the base struct for checks
+// FTWCheck is the base struct for checking test results
 type FTWCheck struct {
-	log      *waflog.FTWLogLines
-	expected *test.Output
+	log       *waflog.FTWLogLines
+	expected  *test.Output
+	overrides *config.FTWTestOverride
 }
 
 // NewCheck creates a new FTWCheck, allowing to inject the configuration
@@ -25,11 +26,15 @@ func NewCheck(c *config.FTWConfiguration) *FTWCheck {
 			Since:        time.Now(),
 			Until:        time.Now(),
 			TimeTruncate: c.LogType.TimeTruncate,
+			LogTruncate:  c.LogTruncate,
 		},
-		expected: &test.Output{},
+		expected:  &test.Output{},
+		overrides: &c.TestOverride,
 	}
 
-	log.Trace().Msgf("check/base: truncate set to %s", check.log.TimeTruncate)
+	log.Trace().Msgf("check/base: time will be truncated to %s", check.log.TimeTruncate)
+	log.Trace().Msgf("check/base: logfile will be truncated? %t", check.log.LogTruncate)
+
 	return check
 }
 
@@ -67,4 +72,22 @@ func (c *FTWCheck) SetLogContains(contains string) {
 // SetNoLogContains sets the string to look that should not present in logs
 func (c *FTWCheck) SetNoLogContains(contains string) {
 	c.expected.NoLogContains = contains
+}
+
+// ForcedIgnore check if this id need to be ignored from results
+func (c *FTWCheck) ForcedIgnore(id string) bool {
+	_, ok := c.overrides.Ignore[id]
+	return ok
+}
+
+// ForcedPass check if this id need to be ignored from results
+func (c *FTWCheck) ForcedPass(id string) bool {
+	_, ok := c.overrides.ForcePass[id]
+	return ok
+}
+
+// ForcedFail check if this id need to be ignored from results
+func (c *FTWCheck) ForcedFail(id string) bool {
+	_, ok := c.overrides.ForceFail[id]
+	return ok
 }

--- a/check/base_test.go
+++ b/check/base_test.go
@@ -24,6 +24,9 @@ logtype:
   timeregex:  '(\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2})'
   timeformat: 'YYYY/MM/DD HH:mm:ss'
   timetruncate: 1s
+testoverride:
+  ignore:
+    '942200-1': 'Ignore Me'
 `
 
 func TestNewCheck(t *testing.T) {
@@ -33,5 +36,29 @@ func TestNewCheck(t *testing.T) {
 
 	if c.log.TimeTruncate != time.Second {
 		t.Errorf("Failed")
+	}
+
+	for _, text := range c.overrides.Ignore {
+		if text != "Ignore Me" {
+			t.Errorf("Well, didn't match Ignore Me")
+		}
+	}
+}
+
+func TestForced(t *testing.T) {
+	config.ImportFromString(yamlNginxConfig)
+
+	c := NewCheck(config.FTWConfig)
+
+	if !c.ForcedIgnore("942200-1") {
+		t.Errorf("Can't find ignored value")
+	}
+
+	if c.ForcedFail("1245") {
+		t.Errorf("Valued should not be found")
+	}
+
+	if c.ForcedPass("1245") {
+		t.Errorf("Valued should not be found")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ func init() {
 
 func initConfig() {
 	config.Init(cfgFile)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	if debug {
 		zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kyokomi/emoji"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
@@ -23,7 +24,9 @@ var runCmd = &cobra.Command{
 		showTime, _ := cmd.Flags().GetBool("time")
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		if !quiet {
-			emoji.Println(":hammer_and_wrench: Starting tests!")
+			log.Info().Msgf(emoji.Sprintf(":hammer_and_wrench: Starting tests!\n"))
+		} else {
+			zerolog.SetGlobalLevel(zerolog.Disabled)
 		}
 		files := fmt.Sprintf("%s/**/*.yaml", dir)
 		tests, err := test.GetTestsFromFiles(files)
@@ -37,7 +40,7 @@ var runCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().StringP("id", "", "", "set test id to run")
-	runCmd.Flags().StringP("exclude", "", "", "exclude tests matching this Go regexp (e.g. to exclude all tests beginning with \"91\", use \"91.*\")")
+	runCmd.Flags().StringP("exclude", "", "", "exclude tests matching this Go regexp (e.g. to exclude all tests beginning with \"91\", use \"91.*\"). If you want more permanent exclusion, check the 'testmodify' option in the config file.")
 	runCmd.Flags().StringP("dir", "d", ".", "recursively find yaml tests in this directory")
 	runCmd.Flags().BoolP("quiet", "q", false, "do not show test by test, only results")
 	runCmd.Flags().BoolP("time", "t", false, "show time spent per test")

--- a/config/config.go
+++ b/config/config.go
@@ -9,8 +9,10 @@ var FTWConfig *FTWConfiguration
 
 // FTWConfiguration FTW global Configuration
 type FTWConfiguration struct {
-	LogFile string
-	LogType FTWLogType
+	LogFile      string
+	LogType      FTWLogType
+	LogTruncate  bool
+	TestOverride FTWTestOverride
 }
 
 // FTWLogType log readers must implement this one
@@ -21,4 +23,14 @@ type FTWLogType struct {
 	TimeRegex    string
 	TimeFormat   string
 	TimeTruncate time.Duration
+}
+
+// FTWTestOverride holds three lists:
+//   Ignore is for tests you want to ignore. It will still execute the test, but ignore the results. You should add a comment on why you ignore the test
+//   ForcePass is for tests you want to pass unconditionally. Test will be executed, and pass even when the test fails. You should add a comment on why you force pass the test
+//   ForceFail is for tests you want to fail unconditionally. Test will be executed, and fail even when the test passes. You should add a comment on why you force fail the test
+type FTWTestOverride struct {
+	Ignore    map[string]string
+	ForcePass map[string]string
+	ForceFail map[string]string
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,9 @@ logtype:
   name: 'apache'
   timeregex:  '\[([A-Z][a-z]{2} [A-z][a-z]{2} \d{1,2} \d{1,2}\:\d{1,2}\:\d{1,2}\.\d+? \d{4})\]'
   timeformat: 'ddd MMM DD HH:mm:ss.S YYYY'
+testoverride:
+  ignore:
+    '920400-1': 'This test result must be ignored'
 `
 
 var yamlBadConfig = `
@@ -30,6 +34,7 @@ logtype:
 var yamlTruncateConfig = `
 ---
 logfile: 'tests/logs/modsec3-nginx/nginx/error.log'
+logtruncate: True
 logtype:
   name: nginx
   timetruncate:  1s
@@ -52,6 +57,19 @@ func TestInitConfig(t *testing.T) {
 
 	if FTWConfig.LogType.TimeFormat != "ddd MMM DD HH:mm:ss.S YYYY" {
 		t.Errorf("Failed !")
+	}
+
+	if len(FTWConfig.TestOverride.Ignore) == 0 {
+		t.Errorf("Failed! Len must be > 0")
+	}
+
+	for id, text := range FTWConfig.TestOverride.Ignore {
+		if !strings.Contains(id, "920400-1") {
+			t.Errorf("Looks like we could not find item to ignore")
+		}
+		if text != "This test result must be ignored" {
+			t.Errorf("Text doesn't match")
+		}
 	}
 }
 
@@ -107,6 +125,9 @@ func TestTimeTruncateConfig(t *testing.T) {
 		t.Errorf("Failed !")
 	}
 
+	if FTWConfig.LogTruncate != true {
+		t.Errorf("Trucate file is wrong !")
+	}
 	if FTWConfig.LogType.TimeTruncate != time.Second {
 		t.Errorf("Failed !")
 	}

--- a/http/response_test.go
+++ b/http/response_test.go
@@ -42,7 +42,6 @@ func TestResponse(t *testing.T) {
 
 	req := generateRequestForTesting()
 
-	fmt.Printf("%+v\n", d)
 	client, err := NewConnection(*d)
 
 	if err != nil {

--- a/runner/stats.go
+++ b/runner/stats.go
@@ -16,15 +16,21 @@ const (
 	Success TestResult = iota
 	Failed
 	Skipped
+	Ignored
+	ForcePass
+	ForceFail
 )
 
 // TestStats accumulates test statistics
 type TestStats struct {
-	Run     int
-	Failed  []string
-	Skipped []string
-	Success int
-	RunTime time.Duration
+	Run        int
+	Failed     []string
+	Skipped    []string
+	Ignored    []string
+	ForcedPass []string
+	ForcedFail []string
+	Success    int
+	RunTime    time.Duration
 }
 
 func addResultToStats(result TestResult, title string, stats *TestStats) {
@@ -35,25 +41,42 @@ func addResultToStats(result TestResult, title string, stats *TestStats) {
 		stats.Failed = append(stats.Failed, title)
 	case Skipped:
 		stats.Skipped = append(stats.Skipped, title)
+	case Ignored:
+		stats.Ignored = append(stats.Ignored, title)
+	case ForceFail:
+		stats.ForcedFail = append(stats.ForcedFail, title)
+	case ForcePass:
+		stats.ForcedPass = append(stats.ForcedPass, title)
 	default:
 		log.Info().Msgf("runner/stats: don't know how to handle TestResult %d", result)
 	}
 }
 
 func printSummary(quiet bool, stats TestStats) {
-	var exitCode int
-	if len(stats.Failed) == 0 && stats.Run > 0 {
-		if !quiet {
+	totalFailed := len(stats.Failed) + len(stats.ForcedFail)
+
+	if !quiet {
+		if stats.Run > 0 {
 			emoji.Printf(":plus:run %d total tests in %s\n", stats.Run, stats.RunTime)
 			emoji.Printf(":next_track_button: skept %d tests\n", len(stats.Skipped))
-			emoji.Println(":tada:All tests successful!")
+			if len(stats.Ignored) > 0 {
+				emoji.Printf(":index_pointing_up: ignored %d tests\n", len(stats.Ignored))
+			}
+			if len(stats.ForcedPass) > 0 {
+				emoji.Printf(":index_pointing_up: forced to pass %d tests\n", len(stats.ForcedPass))
+			}
+			if totalFailed == 0 {
+				emoji.Println(":tada:All tests successful!")
+			} else {
+				emoji.Printf(":thumbs_down:%d test(s) failed to run: %+q\n", len(stats.Failed), stats.Failed)
+				if len(stats.ForcedFail) > 0 {
+					emoji.Printf(":index_pointing_up:%d test(s) were forced to fail: %+q\n", len(stats.ForcedFail), stats.ForcedFail)
+				}
+			}
+		} else {
+			emoji.Println(":person_shrugging:No tests were run")
 		}
-		exitCode = 0
-	} else if len(stats.Failed) > 0 {
-		if !quiet {
-			emoji.Printf(":minus:%d test(s) failed to run: %+q\n", len(stats.Failed), stats.Failed)
-		}
-		exitCode = 1
 	}
-	os.Exit(exitCode)
+
+	os.Exit(totalFailed)
 }

--- a/waflog/base.go
+++ b/waflog/base.go
@@ -11,6 +11,8 @@ type FTWLogLines struct {
 	TimeRegex string
 	// Gostradamus time format, e.g. 'ddd MMM DD HH:mm:ss.S YYYY'
 	TimeFormat string
+	// Truncate Log file. Smaller log files will give smaller search times
+	LogTruncate bool
 	// Truncate time to this time.Duration. Example is nginx logs will be up to the second,
 	// so you want to truncate using '1s'.
 	TimeTruncate time.Duration


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- Allows tests to be overriden by using a map of `test_id`, `text`.
- Added a new config setting to truncate logs