### PR TITLE
fix(core): change returning as Go err to using os.Exit instead

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"os"
+
 	config "github.com/fzipi/go-ftw/config"
 
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +26,7 @@ var rootCmd = &cobra.Command{
 func Execute(version string) {
 	rootCmd.Version = version
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal().Msgf("Problem executing: %s", err.Error())
+		os.Exit(1)
 	}
 }
 
@@ -35,7 +36,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "c", "override config file (default is $PWD/.ftw.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "override config file (default is $PWD/.ftw.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "", false, "debug output")
 	rootCmd.PersistentFlags().BoolVarP(&trace, "trace", "", false, "trace output: really, really verbose")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
+	"os"
 
 	"github.com/kyokomi/emoji"
 	"github.com/rs/zerolog"
@@ -18,7 +18,7 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run Tests",
 	Long:  `Run all tests below a certain subdirectory. The command will search all y[a]ml files recursively and pass it to the test engine.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
 		exclude, _ := cmd.Flags().GetString("exclude")
 		include, _ := cmd.Flags().GetString("include")
 		id, _ := cmd.Flags().GetString("id")
@@ -32,18 +32,18 @@ var runCmd = &cobra.Command{
 		}
 		if id != "" {
 			log.Fatal().Msgf("--id is deprecated in favour of --include|-i")
-			return errors.New("use --include instead")
 		}
 		if exclude != "" && include != "" {
 			log.Fatal().Msgf("You need to choose one: use --include (%s) or --exclude (%s)", include, exclude)
-			return errors.New("choose one between --include or --exclude")
 		}
 		files := fmt.Sprintf("%s/**/*.yaml", dir)
 		tests, err := test.GetTestsFromFiles(files)
+
 		if err != nil {
-			log.Error().Msg(err.Error())
+			log.Fatal().Err(err)
 		}
-		return runner.Run(include, exclude, showTime, quiet, tests)
+
+		os.Exit(runner.Run(include, exclude, showTime, quiet, tests))
 	},
 }
 

--- a/runner/run.go
+++ b/runner/run.go
@@ -1,7 +1,6 @@
 package runner
 
 import (
-	"errors"
 	"regexp"
 	"time"
 
@@ -19,7 +18,7 @@ import (
 // testid is the name of the unique test you want to run
 // exclude is a regexp that matches the test name: e.g. "920*", excludes all tests starting with "920"
 // Returns error if some test failed
-func Run(include string, exclude string, showTime bool, output bool, ftwtests []test.FTWTest) error {
+func Run(include string, exclude string, showTime bool, output bool, ftwtests []test.FTWTest) int {
 	var testResult TestResult
 	var stats TestStats
 	var duration time.Duration
@@ -130,11 +129,7 @@ func Run(include string, exclude string, showTime bool, output bool, ftwtests []
 		}
 	}
 
-	if res := printSummary(output, stats); res > 0 {
-		return errors.New("some test failed")
-	}
-
-	return nil
+	return printSummary(output, stats)
 }
 
 func needToSkipTest(include string, exclude string, title string, skip bool) bool {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -124,25 +124,25 @@ func TestRun(t *testing.T) {
 	tests, _ := test.GetTestsFromFiles(filename)
 
 	t.Run("showtime and execute all", func(t *testing.T) {
-		if err := Run("*", "", false, true, tests); err != nil {
+		if res := Run("*", "", false, true, tests); res > 0 {
 			t.Error("Oops, test run failed!")
 		}
 	})
 
 	t.Run("don't showtime and execute all", func(t *testing.T) {
-		if err := Run("*", "", false, false, tests); err != nil {
+		if res := Run("*", "", false, false, tests); res > 0 {
 			t.Error("Oops, test run failed!")
 		}
 	})
 
 	t.Run("execute only test 008 but exclude all", func(t *testing.T) {
-		if err := Run("008", "", false, false, tests); err != nil {
+		if res := Run("008", "", false, false, tests); res > 0 {
 			t.Error("Oops, test run failed!")
 		}
 	})
 
 	t.Run("exclude test 010", func(t *testing.T) {
-		if err := Run("*", "010", false, false, tests); err != nil {
+		if res := Run("*", "010", false, false, tests); res > 0 {
 			t.Error("Oops, test run failed!")
 		}
 	})


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This one fixes error output even when tests were succesful