### PR TITLE
feat(cookies): add cookie support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,5 +20,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/yargevad/filepathx v1.0.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,7 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/http/client.go
+++ b/http/client.go
@@ -1,0 +1,79 @@
+package http
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http/cookiejar"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/net/publicsuffix"
+)
+
+// NewClient initializes the http client, creating the cookiejar
+func NewClient() *Client {
+	// All users of cookiejar should import "golang.org/x/net/publicsuffix"
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+	c := &Client{
+		Jar: jar,
+		// default Timeout
+		Timeout: 3 * time.Second,
+	}
+	return c
+}
+
+// NewConnection creates a new Connection based on a Destination
+func (c *Client) NewConnection(d Destination) error {
+	var err error
+	var netConn net.Conn
+
+	hostPort := fmt.Sprintf("%s:%d", d.DestAddr, d.Port)
+
+	// Fatal error: dial tcp 127.0.0.1:80: connect: connection refused
+	// strings.HasSuffix(err.String(), "connection refused") {
+	if strings.ToLower(d.Protocol) == "https" {
+		// Commenting InsecureSkipVerify: true.
+		netConn, err = tls.DialWithDialer(&net.Dialer{Timeout: c.Timeout}, "tcp", hostPort, &tls.Config{})
+	} else {
+		netConn, err = net.DialTimeout("tcp", hostPort, c.Timeout)
+	}
+
+	if err == nil {
+		c.Transport = &Connection{
+			connection: netConn,
+			protocol:   d.Protocol,
+			duration:   NewRoundTripTime(),
+		}
+	}
+
+	return err
+}
+
+// Do performs the http request roundtrip
+func (c *Client) Do(req Request) (*Response, error) {
+	var response *Response
+
+	err := c.Transport.Request(&req)
+
+	if err != nil {
+		log.Error().Msgf("http/client: error sending request: %s\n", err.Error())
+	} else {
+		response, err = c.Transport.Response()
+		if err != nil {
+			log.Debug().Msgf("ftw/run: error receiving response: %s\n", err.Error())
+			// This error might be expected. Let's continue
+		}
+	}
+
+	return response, err
+}
+
+// GetRoundTripTime returns the time taken from the initial send till receiving the full response
+func (c *Client) GetRoundTripTime() *RoundTripTime {
+	return c.Transport.GetRoundTripTime()
+}

--- a/http/request.go
+++ b/http/request.go
@@ -133,7 +133,7 @@ func (r *Request) AddStandardHeaders(size int) {
 }
 
 // Request will use all the inputs and send a raw http request to the destination
-func (c *Connection) Request(request *Request) (*Connection, error) {
+func (c *Connection) Request(request *Request) error {
 	// Build request first, then connect and send, so timers are accurate
 	data, err := buildRequest(request)
 	if err != nil {
@@ -148,7 +148,7 @@ func (c *Connection) Request(request *Request) (*Connection, error) {
 		log.Error().Msgf("ftw/http: error writing data: %s", err.Error())
 	}
 
-	return c, err
+	return err
 }
 
 // isRaw is a helper that returns true if raw or encoded data

--- a/http/types.go
+++ b/http/types.go
@@ -1,18 +1,23 @@
 package http
 
 import (
-	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
 )
 
+// Client is the top level abstraction in http
+type Client struct {
+	Transport *Connection
+	Jar       http.CookieJar
+	Timeout   time.Duration
+}
+
 // Connection is the type used for sending/receiving data
 type Connection struct {
-	netConn  net.Conn
-	tlsConn  *tls.Conn
-	protocol string
-	duration *RoundTripTime
+	connection net.Conn
+	protocol   string
+	duration   *RoundTripTime
 }
 
 // RoundTripTime abstracts the time a transaction takes


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This PR add the last remaining part for compatibility with `ftw`: cookies.

While they are not used actively in the `coreruleset` tests, they are part of `ftw`, so we needed to cover that.

Cookies needed to be integrated at a higher level than connections with the tested waf. They are part of the HTTP client, and need to be active while we run all tests. That way when a server sends any cookie back, the client can add the cookies to the request.