### PR TITLE
feat(override): adds feature for everriding host and port globally

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,11 +25,13 @@ type FTWLogType struct {
 	TimeTruncate time.Duration `koanf:"timetruncate"`
 }
 
-// FTWTestOverride holds three lists:
+// FTWTestOverride holds four lists:
+//   Global allows you to override global parameters in tests. An example usage is if you want to change the `dest_addr` of all tests to point to an external IP or host.
 //   Ignore is for tests you want to ignore. It will still execute the test, but ignore the results. You should add a comment on why you ignore the test
 //   ForcePass is for tests you want to pass unconditionally. Test will be executed, and pass even when the test fails. You should add a comment on why you force pass the test
 //   ForceFail is for tests you want to fail unconditionally. Test will be executed, and fail even when the test passes. You should add a comment on why you force fail the test
 type FTWTestOverride struct {
+	Input     map[string]string `koanf:"input"`
 	Ignore    map[string]string `koanf:"ignore"`
 	ForcePass map[string]string `koanf:"forcepass"`
 	ForceFail map[string]string `koanf:"forcefail"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,14 +9,16 @@ import (
 	"github.com/fzipi/go-ftw/utils"
 )
 
-var yamlConfig = `
----
+var yamlConfig = `---
 logfile: 'tests/logs/modsec2-apache/apache2/error.log'
 logtype:
   name: 'apache'
-  timeregex:  '\[([A-Z][a-z]{2} [A-z][a-z]{2} \d{1,2} \d{1,2}\:\d{1,2}\:\d{1,2}\.\d+? \d{4})\]'
+  timeregex: '\[([A-Z][a-z]{2} [A-z][a-z]{2} \d{1,2} \d{1,2}\:\d{1,2}\:\d{1,2}\.\d+? \d{4})\]'
   timeformat: 'ddd MMM DD HH:mm:ss.S YYYY'
 testoverride:
+  input:
+    dest_addr: 'httpbin.org'
+    port: '1234'
   ignore:
     '920400-1': 'This test result must be ignored'
 `
@@ -38,7 +40,6 @@ logtype:
   name: nginx
   timetruncate:  1s
   timeformat: 'ddd MMM DD HH:mm:ss'
-
 `
 
 var jsonConfig = `
@@ -68,12 +69,22 @@ func TestInitConfig(t *testing.T) {
 		t.Errorf("Failed! Len must be > 0")
 	}
 
+	if len(FTWConfig.TestOverride.Input) == 0 {
+		t.Errorf("Failed! Input Len must be > 0")
+	}
+
 	for id, text := range FTWConfig.TestOverride.Ignore {
 		if !strings.Contains(id, "920400-1") {
 			t.Errorf("Looks like we could not find item to ignore")
 		}
 		if text != "This test result must be ignored" {
 			t.Errorf("Text doesn't match")
+		}
+	}
+
+	for setting, value := range FTWConfig.TestOverride.Input {
+		if setting == "dest_addr" && value != "httpbin.org" {
+			t.Errorf("Looks like we are not overriding destination!")
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- allows you to override all tests host and port

First part for #42.