### PR TITLE
fix(namespace): avoid collision with base http

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,10 +30,22 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
+  use: github
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: Others
+      order: 999
   filters:
     exclude:
       - '^docs'
       - '^test'
+release:
+  prerelease: auto
 
 nfpms:
   - id: "ftw"
@@ -49,10 +61,10 @@ nfpms:
         file_name_template: "{{ .ProjectName }}-{{ .Version }}.{{ .Arch }}"
       deb:
         file_name_template: "{{ .ProjectName }}-{{ .Version }}_{{ .Arch }}"
-    vendor: 
+    vendor:
     homepage: https://github.com/fzipi/go-ftw
     maintainer: felipe.zipitria@owasp.org
-    description: 
+    description:
       Framework for Testing WAFs - Go version
 
       It uses the OWASP Core Ruleset V3 as a baseline to test rules on a WAF. Each rule from the ruleset is loaded into a YAML file that issues HTTP requests that will trigger these rules. Users can verify the execution of the rule after the tests are issued to make sure the expected response is received from an attack

--- a/ftwhttp/client.go
+++ b/ftwhttp/client.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import (
 	"crypto/tls"

--- a/ftwhttp/client_test.go
+++ b/ftwhttp/client_test.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import "testing"
 

--- a/ftwhttp/connection.go
+++ b/ftwhttp/connection.go
@@ -1,5 +1,5 @@
-// Package http provides low level abstractions for sending/receiving raw http messages
-package http
+// Package ftwhttp provides low level abstractions for sending/receiving raw http messages
+package ftwhttp
 
 import (
 	"bufio"
@@ -16,8 +16,11 @@ import (
 )
 
 // DestinationFromString create a Destination from String
-func DestinationFromString(urlString string) *Destination {
-	u, _ := url.Parse(urlString)
+func DestinationFromString(urlString string) (*Destination, error) {
+	u, err := url.Parse(urlString)
+	if err != nil {
+		return nil, err
+	}
 	host, port, _ := net.SplitHostPort(u.Host)
 	p, _ := strconv.Atoi(port)
 
@@ -27,7 +30,7 @@ func DestinationFromString(urlString string) *Destination {
 		Protocol: u.Scheme,
 	}
 
-	return d
+	return d, nil
 }
 
 // StartTrackingTime initializes timer

--- a/ftwhttp/connection_test.go
+++ b/ftwhttp/connection_test.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import "testing"
 

--- a/ftwhttp/header.go
+++ b/ftwhttp/header.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import (
 	"bytes"

--- a/ftwhttp/header_test.go
+++ b/ftwhttp/header_test.go
@@ -6,7 +6,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package http
+package ftwhttp
 
 import (
 	"bytes"

--- a/ftwhttp/request.go
+++ b/ftwhttp/request.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import (
 	"bytes"

--- a/ftwhttp/request_test.go
+++ b/ftwhttp/request_test.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import (
 	"bytes"

--- a/ftwhttp/response.go
+++ b/ftwhttp/response.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import (
 	"io"

--- a/ftwhttp/response_test.go
+++ b/ftwhttp/response_test.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import (
 	"fmt"
@@ -81,12 +81,15 @@ func TestResponse(t *testing.T) {
 
 	defer server.Close()
 
-	d := DestinationFromString(server.URL)
+	d, err := DestinationFromString(server.URL)
 
+	if err != nil {
+		t.Error(err)
+	}
 	req := generateRequestForTesting(true)
 
 	client := NewClient()
-	err := client.NewConnection(*d)
+	err = client.NewConnection(*d)
 
 	if err != nil {
 		t.Fatalf("Error! %s", err.Error())
@@ -109,12 +112,14 @@ func TestResponseWithCookies(t *testing.T) {
 
 	defer server.Close()
 
-	d := DestinationFromString(server.URL)
-
+	d, err := DestinationFromString(server.URL)
+	if err != nil {
+		t.Fatalf("Error! %s", err.Error())
+	}
 	req := generateRequestForTesting(true)
 
 	client := NewClient()
-	err := client.NewConnection(*d)
+	err = client.NewConnection(*d)
 
 	if err != nil {
 		t.Fatalf("Error! %s", err.Error())

--- a/ftwhttp/rtt.go
+++ b/ftwhttp/rtt.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import "time"
 

--- a/ftwhttp/types.go
+++ b/ftwhttp/types.go
@@ -1,4 +1,4 @@
-package http
+package ftwhttp
 
 import (
 	"net"

--- a/runner/run.go
+++ b/runner/run.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/fzipi/go-ftw/check"
 	"github.com/fzipi/go-ftw/config"
-	"github.com/fzipi/go-ftw/http"
+	"github.com/fzipi/go-ftw/ftwhttp"
 	"github.com/fzipi/go-ftw/test"
 	"github.com/fzipi/go-ftw/utils"
 
@@ -27,7 +27,7 @@ func Run(include string, exclude string, showTime bool, output bool, ftwtests []
 
 	printUnlessQuietMode(output, ":rocket:Running go-ftw!\n")
 
-	client := http.NewClient()
+	client := ftwhttp.NewClient()
 
 	for _, tests := range ftwtests {
 		changed := true
@@ -69,10 +69,10 @@ func Run(include string, exclude string, showTime bool, output bool, ftwtests []
 					continue
 				}
 
-				var req *http.Request
+				var req *ftwhttp.Request
 
 				// Destination is needed for an request
-				dest := &http.Destination{
+				dest := &ftwhttp.Destination{
 					DestAddr: testRequest.GetDestAddr(),
 					Port:     testRequest.GetPort(),
 					Protocol: testRequest.GetProtocol(),
@@ -179,7 +179,7 @@ func overridenTestResult(c *check.FTWCheck, id string) TestResult {
 }
 
 // checkResult has the logic for verifying the result for the test sent
-func checkResult(c *check.FTWCheck, response *http.Response, responseError error) TestResult {
+func checkResult(c *check.FTWCheck, response *ftwhttp.Response, responseError error) TestResult {
 	// Request might return an error, but it could be expected, we check that first
 	if responseError != nil && c.AssertExpectError(responseError) {
 		return Success
@@ -214,8 +214,8 @@ func checkResult(c *check.FTWCheck, response *http.Response, responseError error
 	return Failed
 }
 
-func getRequestFromTest(testRequest test.Input) *http.Request {
-	var req *http.Request
+func getRequestFromTest(testRequest test.Input) *ftwhttp.Request {
+	var req *ftwhttp.Request
 	// get raw request, if anything
 	raw, err := testRequest.GetRawRequest()
 	if err != nil {
@@ -224,9 +224,9 @@ func getRequestFromTest(testRequest test.Input) *http.Request {
 
 	// If we use raw or encoded request, then we don't use other fields
 	if raw != nil {
-		req = http.NewRawRequest(raw, !testRequest.StopMagic)
+		req = ftwhttp.NewRawRequest(raw, !testRequest.StopMagic)
 	} else {
-		rline := &http.RequestLine{
+		rline := &ftwhttp.RequestLine{
 			Method:  testRequest.GetMethod(),
 			URI:     testRequest.GetURI(),
 			Version: testRequest.GetVersion(),
@@ -234,7 +234,7 @@ func getRequestFromTest(testRequest test.Input) *http.Request {
 
 		data := testRequest.ParseData()
 		// create a new request
-		req = http.NewRequest(rline, testRequest.Headers,
+		req = ftwhttp.NewRequest(rline, testRequest.Headers,
 			data, !testRequest.StopMagic)
 
 	}

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/fzipi/go-ftw/config"
-	httpftw "github.com/fzipi/go-ftw/http"
+	"github.com/fzipi/go-ftw/ftwhttp"
 	"github.com/fzipi/go-ftw/test"
 	"github.com/fzipi/go-ftw/utils"
 )
@@ -259,9 +259,7 @@ func newTestServer() *httptest.Server {
 }
 
 // replace localhost or 127.0.0.1 in tests with test url
-func replaceLocalhostWithTestServer(yaml string, url string) string {
-	d := httpftw.DestinationFromString(url)
-
+func replaceLocalhostWithTestServer(yaml string, d ftwhttp.Destination) string {
 	destChanged := strings.ReplaceAll(yaml, "TEST_ADDR", d.DestAddr)
 	replacedYaml := strings.ReplaceAll(destChanged, "TEST_PORT", strconv.Itoa(d.Port))
 
@@ -280,7 +278,11 @@ func TestRun(t *testing.T) {
 
 	// setup test webserver (not a waf)
 	server := newTestServer()
-	yamlTestContent := replaceLocalhostWithTestServer(yamlTest, server.URL)
+	d, err := ftwhttp.DestinationFromString(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse destination")
+	}
+	yamlTestContent := replaceLocalhostWithTestServer(yamlTest, *d)
 
 	filename, err := utils.CreateTempFileWithContent(yamlTestContent, "goftw-test-*.yaml")
 	if err != nil {
@@ -492,7 +494,11 @@ func TestFailedTestsRun(t *testing.T) {
 
 	// setup test webserver (not a waf)
 	server := newTestServer()
-	yamlTestContent := replaceLocalhostWithTestServer(yamlFailedTest, server.URL)
+	d, err := ftwhttp.DestinationFromString(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse destination")
+	}
+	yamlTestContent := replaceLocalhostWithTestServer(yamlFailedTest, *d)
 
 	filename, err := utils.CreateTempFileWithContent(yamlTestContent, "goftw-test-*.yaml")
 	if err != nil {

--- a/test/defaults_test.go
+++ b/test/defaults_test.go
@@ -4,31 +4,14 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fzipi/go-ftw/http"
+	"github.com/fzipi/go-ftw/ftwhttp"
 )
-
-/*
-type Input struct {
-	DestAddr       *string     `yaml:"dest_addr,omitempty"`
-	Port           *int        `yaml:"port,omitempty"`
-	Protocol       *string     `yaml:"protocol,omitempty"`
-	URI            *string     `yaml:"uri,omitempty"`
-	Version        *string     `yaml:"version,omitempty"`
-	Headers        http.Header `yaml:"headers,omitempty"`
-	Method         *string     `yaml:"method,omitempty"`
-	Data           string      `yaml:"data,omitempty"`
-	SaveCookie     bool        `yaml:"save_cookie,omitempty"`
-	StopMagic      bool        `yaml:"stop_magic"`
-	EncodedRequest string      `yaml:"encoded_request,omitempty"`
-	RAWRequest     string      `yaml:"raw_request,omitempty"`
-}
-*/
 
 func getTestInputDefaults() *Input {
 	data := "My Data"
 
 	inputDefaults := Input{
-		Headers:    make(http.Header),
+		Headers:    make(ftwhttp.Header),
 		Data:       &data,
 		SaveCookie: false,
 		StopMagic:  false,
@@ -50,7 +33,7 @@ func getTestExampleInput() *Input {
 		Protocol:       &protocol,
 		URI:            &uri,
 		Version:        &version,
-		Headers:        make(http.Header),
+		Headers:        make(ftwhttp.Header),
 		Method:         &method,
 		Data:           nil,
 		EncodedRequest: "TXkgRGF0YQo=",

--- a/test/types.go
+++ b/test/types.go
@@ -1,22 +1,22 @@
 package test
 
-import "github.com/fzipi/go-ftw/http"
+import "github.com/fzipi/go-ftw/ftwhttp"
 
 // Input represents the input request in a stage
 // The fields `Version`, `Method` and `URI` we want to explicitly now when they are set to ""
 type Input struct {
-	DestAddr       *string     `yaml:"dest_addr,omitempty"`
-	Port           *int        `yaml:"port,omitempty"`
-	Protocol       *string     `yaml:"protocol,omitempty"`
-	URI            *string     `yaml:"uri,omitempty"`
-	Version        *string     `yaml:"version,omitempty"`
-	Headers        http.Header `yaml:"headers,omitempty"`
-	Method         *string     `yaml:"method,omitempty"`
-	Data           *string     `yaml:"data,omitempty"`
-	SaveCookie     bool        `yaml:"save_cookie,omitempty"`
-	StopMagic      bool        `yaml:"stop_magic"`
-	EncodedRequest string      `yaml:"encoded_request,omitempty"`
-	RAWRequest     string      `yaml:"raw_request,omitempty"`
+	DestAddr       *string        `yaml:"dest_addr,omitempty"`
+	Port           *int           `yaml:"port,omitempty"`
+	Protocol       *string        `yaml:"protocol,omitempty"`
+	URI            *string        `yaml:"uri,omitempty"`
+	Version        *string        `yaml:"version,omitempty"`
+	Headers        ftwhttp.Header `yaml:"headers,omitempty"`
+	Method         *string        `yaml:"method,omitempty"`
+	Data           *string        `yaml:"data,omitempty"`
+	SaveCookie     bool           `yaml:"save_cookie,omitempty"`
+	StopMagic      bool           `yaml:"stop_magic"`
+	EncodedRequest string         `yaml:"encoded_request,omitempty"`
+	RAWRequest     string         `yaml:"raw_request,omitempty"`
 }
 
 // Output is the response expected from the test


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- Rename http to ftwhttp to avoid collision with base namespace
- Add editorconfig
- Extend goreleaser config to match RC versions.