### PR TITLE
fix: override port with missing port inside test.

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -363,7 +363,7 @@ func applyInputOverride(testRequest *test.Input) error {
 			if err != nil {
 				retErr = errors.New("ftw/run: error getting overriden port")
 			}
-			*testRequest.Port = port
+			testRequest.Port = &port
 		case "dest_addr":
 			oDestAddr := &value
 			testRequest.DestAddr = oDestAddr


### PR DESCRIPTION
Hi there!
Running the CRS, I bumped into some `SIGSEGV: segmentation violation` because my config has a port override specification, but some rules do not populate the `port:` field. It leads to a nil pointer error, trying to override a not existing value.

- Example of rule that led to a crash: [913120-2](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/tests/regression/tests/REQUEST-913-SCANNER-DETECTION/913120.yaml#L29-L42)
- Snippet of `.ftw.yaml`:
```
testoverride:
  input:
    port: '80'
```
- Crash output example:
```
$ go run github.com/fzipi/go-ftw@448ecfb02d0128a04ccde3bb601797f7f19eda3f run -d crs-regression-test-v3.3.2/tests/ -i 913120 -t
9:07AM INF 🛠️  Starting tests!

9:07AM INF Integer node found where ArrayNode is expected
🚀 Running go-ftw!
👉 executing tests in file 913120.yaml
	running 913120-1: ✔ passed in 30.864333ms (RTT 258ns)
	running 913120-2: panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x80401d]

goroutine 1 [running]:
github.com/fzipi/go-ftw/runner.applyInputOverride(0xc0001c72f8)
	/home/matteopace/go/pkg/mod/github.com/fzipi/go-ftw@v0.4.0-rc3.0.20220530185153-448ecfb02d01/runner/run.go:366 +0x17d
github.com/fzipi/go-ftw/runner.RunStage(0xc0001c77d0, 0xc0001c74d8, {{0xc00036f280, 0x8}, {0xc0002df260, 0x50}, {0xc00037a540, _, _}}, {{0xc0003931d0, ...}, ...})
	/home/matteopace/go/pkg/mod/github.com/fzipi/go-ftw@v0.4.0-rc3.0.20220530185153-448ecfb02d01/runner/run.go:94 +0xe5
github.com/fzipi/go-ftw/runner.RunTest(0xc0001c77d0, {{0xc0002b90e0, 0x4a}, {{0xc00036ecd0, 0xc}, 0x1, {0xc00036edb0, 0xb}, {0xc00036eca9, 0x4}}, ...})
	/home/matteopace/go/pkg/mod/github.com/fzipi/go-ftw@v0.4.0-rc3.0.20220530185153-448ecfb02d01/runner/run.go:79 +0x48e
github.com/fzipi/go-ftw/runner.Run({0x7ffc9954747e, _}, {_, _}, _, _, {_, _, _})
	/home/matteopace/go/pkg/mod/github.com/fzipi/go-ftw@v0.4.0-rc3.0.20220530185153-448ecfb02d01/runner/run.go:43 +0x365
github.com/fzipi/go-ftw/cmd.glob..func2(0xd7cee0?, {0x8a3b7b?, 0x5?, 0x5?})
	/home/matteopace/go/pkg/mod/github.com/fzipi/go-ftw@v0.4.0-rc3.0.20220530185153-448ecfb02d01/cmd/run.go:46 +0x3a5
github.com/spf13/cobra.(*Command).execute(0xd7cee0, {0xc0000d2730, 0x5, 0x5})
	/home/matteopace/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:856 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0xd7cc60)
	/home/matteopace/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x39c
github.com/spf13/cobra.(*Command).Execute(...)
	/home/matteopace/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
github.com/fzipi/go-ftw/cmd.Execute({0x8a3675?, 0x383b81?})
	/home/matteopace/go/pkg/mod/github.com/fzipi/go-ftw@v0.4.0-rc3.0.20220530185153-448ecfb02d01/cmd/root.go:30 +0x51
main.main()
	/home/matteopace/go/pkg/mod/github.com/fzipi/go-ftw@v0.4.0-rc3.0.20220530185153-448ecfb02d01/main.go:40 +0x255
exit status 2
```

This PR proposes a fix directly assigning the pointer to the overridden port regardless of whether the `port` field exists or not. A test related to it is also added. 

cc: @jcchavezs

