### PR TITLE
chore: improving output for overridden tests

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -61,7 +61,7 @@ func RunTest(runContext *TestRunContext, ftwTest test.FTWTest) {
 		if needToSkipTest(runContext.Include, runContext.Exclude, testCase.TestTitle, ftwTest.Meta.Enabled) {
 			addResultToStats(Skipped, testCase.TestTitle, &runContext.Stats)
 			if !ftwTest.Meta.Enabled {
-				printUnlessQuietMode(runContext.Output, "Skipping test %s\n", testCase.TestTitle)
+				printUnlessQuietMode(runContext.Output, "\tskipping %s\n", testCase.TestTitle)
 			}
 			continue
 		}
@@ -102,9 +102,10 @@ func RunStage(runContext *TestRunContext, ftwCheck *check.FTWCheck, testCase tes
 		log.Fatal().Msgf("ftw/run: bad test: choose between data, encoded_request, or raw_request")
 	}
 
-	// Do not even run test if result is overriden. Just use the override.
+	// Do not even run test if result is overridden. Just use the override and display the overridden result.
 	if overriden := overridenTestResult(ftwCheck, testCase.TestTitle); overriden != Failed {
 		addResultToStats(overriden, testCase.TestTitle, &runContext.Stats)
+		displayResult(runContext.Output, overriden, time.Duration(0), time.Duration(0))
 		return
 	}
 
@@ -257,7 +258,11 @@ func displayResult(quiet bool, result TestResult, roundTripTime time.Duration, s
 	case Failed:
 		printUnlessQuietMode(quiet, ":collision:failed in %s (RTT %s)\n", stageTime, roundTripTime)
 	case Ignored:
-		printUnlessQuietMode(quiet, ":equal:test result ignored in %s (RTT %s)\n", stageTime, roundTripTime)
+		printUnlessQuietMode(quiet, ":information:test ignored\n")
+	case ForceFail:
+		printUnlessQuietMode(quiet, ":information:test forced to fail\n")
+	case ForcePass:
+		printUnlessQuietMode(quiet, ":information:test forced to pass\n")
 	default:
 		// don't print anything if skipped test
 	}


### PR DESCRIPTION
Hi!
Super small PR just to propose some output improvements when `testoverride` is in place.
As far as I understand, overridden tests are not going to be anymore executed, but directly [skipped here](https://github.com/fzipi/go-ftw/blob/main/runner/run.go#L105-L108). So the [`case Ignored:`](https://github.com/fzipi/go-ftw/blob/main/runner/run.go#L259-L260) of the `displayResult` is never going to be executed.
This PR runs `displayResult` also when tests are skipped and adds `ForceFail` and `ForcePass` cases.

Before:
```
👉 executing tests in file 911100.yaml
  running 911100-1:   running 911100-2: ✔ passed in 22.314279ms (RTT 95ns)
  running 911100-3:   running 911100-4:   running 911100-5: ✔ passed in 21.243191ms (RTT 114ns)
  running 911100-6: ✔ passed in 21.226411ms (RTT 83ns)
  running 911100-7: ✔ passed in 20.805399ms (RTT 87ns)
  running 911100-8: ✔ passed in 24.465528ms (RTT 145ns)
👉 executing tests in file 913100.yaml
```

After:
```
👉 executing tests in file 911100.yaml
  running 911100-1: ℹ test ignored
  running 911100-2: ✔ passed in 18.378367ms (RTT 105ns)
  running 911100-3: ℹ test ignored
  running 911100-4: ℹ test ignored
  running 911100-5: ✔ passed in 16.909262ms (RTT 93ns)
  running 911100-6: ✔ passed in 16.720614ms (RTT 101ns)
  running 911100-7: ✔ passed in 15.931623ms (RTT 83ns)
  running 911100-8: ✔ passed in 16.56331ms (RTT 92ns)
👉 executing tests in file 913100.yaml
  running 913100-1: ℹ test forced to fail
  running 913100-2: ✔ passed in 17.998401ms (RTT 117ns)
  running 913100-3: ✔ passed in 18.571974ms (RTT 93ns)
  running 913100-4: ✔ passed in 18.721675ms (RTT 89ns)
  running 913100-5: ℹ test forced to pass
  running 913100-6: ✔ passed in 18.704162ms (RTT 110ns)
  running 913100-7: ✔ passed in 18.86057ms (RTT 119ns)
```

Small change also when tests are skept, following the "running testCase"  convention:
Before:
```
  running 920350-7: ✔ passed in 19.151645ms (RTT 124ns)
  running 920350-8: ✔ passed in 18.921425ms (RTT 99ns)
Skipping test 920360-1
Skipping test 920370-1
Skipping test 920380-1
Skipping test 920390-1
👉 executing tests in file 920400.yaml
  running 920400-1: ✔ passed in 1.015061419s (RTT 110ns)
```
After:
```
  running 920350-7: ✔ passed in 18.814176ms (RTT 113ns)
  running 920350-8: ✔ passed in 28.909927ms (RTT 103ns)
  skipping 920360-1
  skipping 920370-1
  skipping 920380-1
  skipping 920390-1
👉 executing tests in file 920400.yaml
  running 920400-1: ✔ passed in 1.014892213s (RTT 147ns)
```