### PR TITLE
When overriding dest_addr, also override Host header

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -372,6 +372,11 @@ func applyInputOverride(testRequest *test.Input) error {
 		case "dest_addr":
 			oDestAddr := &value
 			testRequest.DestAddr = oDestAddr
+			// Work around "running 920171-1: panic: assignment to entry in nil map"
+			// TODO: maybe create Header map instead?
+			if testRequest.Headers != nil {
+				testRequest.Headers.Set("Host", value)
+			}
 		case "protocol":
 			oProtocol := &value
 			testRequest.Protocol = oProtocol


### PR DESCRIPTION
This is my local fix for https://github.com/fzipi/go-ftw/issues/60.
Seems to work well enough here, though the problem running 920171-1 which prompted the nil check could use a look.