### PR TITLE
feat: set "Host" header from dest_addr override

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 // or uses `.ftw.yaml` as default file
 func NewConfigFromFile(cfgFile string) error {
 	// kaonf merges by default but we never want to merge in this case
-	FTWConfig = nil
+	Reset()
 
 	// Global koanf instance. Use "." as the key path delimiter. This can be "/" or any character.
 	var k = koanf.New(".")
@@ -47,7 +47,7 @@ func NewConfigFromFile(cfgFile string) error {
 // NewConfigFromEnv reads configuration information from environment variables that start with `FTW_`
 func NewConfigFromEnv() error {
 	// kaonf merges by default but we never want to merge in this case
-	FTWConfig = nil
+	Reset()
 
 	var err error
 	var k = koanf.New(".")
@@ -70,7 +70,7 @@ func NewConfigFromEnv() error {
 // NewConfigFromString initializes the configuration from a yaml formatted string. Useful for testing.
 func NewConfigFromString(conf string) error {
 	// kaonf merges by default but we never want to merge in this case
-	FTWConfig = nil
+	Reset()
 
 	var k = koanf.New(".")
 	var err error
@@ -85,6 +85,11 @@ func NewConfigFromString(conf string) error {
 	loadDefaults()
 
 	return err
+}
+
+// Reset configuration to uninitialized state
+func Reset() {
+	FTWConfig = nil
 }
 
 func loadDefaults() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -53,8 +54,8 @@ func TestNewConfigConfig(t *testing.T) {
 		t.Errorf("Failed! Len must be > 0")
 	}
 
-	if len(FTWConfig.TestOverride.Input) == 0 {
-		t.Errorf("Failed! Input Len must be > 0")
+	if reflect.ValueOf(FTWConfig.TestOverride.Input).IsZero() {
+		t.Errorf("Failed! Input must not be empty")
 	}
 
 	for id, text := range FTWConfig.TestOverride.Ignore {
@@ -66,12 +67,10 @@ func TestNewConfigConfig(t *testing.T) {
 		}
 	}
 
-	for setting, value := range FTWConfig.TestOverride.Input {
-		if setting == "dest_addr" && value != "httpbin.org" {
-			t.Errorf("Looks like we are not overriding destination!")
-		}
+	overrides := FTWConfig.TestOverride.Input
+	if overrides.DestAddr != nil && *overrides.DestAddr != "httpbin.org" {
+		t.Errorf("Looks like we are not overriding destination!")
 	}
-
 }
 
 func TestNewConfigBadConfig(t *testing.T) {

--- a/config/types.go
+++ b/config/types.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/fzipi/go-ftw/test"
+
 // RunMode represents the mode of the test run
 type RunMode string
 
@@ -24,12 +26,13 @@ type FTWConfiguration struct {
 }
 
 // FTWTestOverride holds four lists:
-//   Global allows you to override global parameters in tests. An example usage is if you want to change the `dest_addr` of all tests to point to an external IP or host.
-//   Ignore is for tests you want to ignore. It will still execute the test, but ignore the results. You should add a comment on why you ignore the test
-//   ForcePass is for tests you want to pass unconditionally. Test will be executed, and pass even when the test fails. You should add a comment on why you force pass the test
-//   ForceFail is for tests you want to fail unconditionally. Test will be executed, and fail even when the test passes. You should add a comment on why you force fail the test
+//
+//	Input allows you to override input parameters in tests. An example usage is if you want to change the `dest_addr` of all tests to point to an external IP or host.
+//	Ignore is for tests you want to ignore. It will still execute the test, but ignore the results. You should add a comment on why you ignore the test
+//	ForcePass is for tests you want to pass unconditionally. Test will be executed, and pass even when the test fails. You should add a comment on why you force pass the test
+//	ForceFail is for tests you want to fail unconditionally. Test will be executed, and fail even when the test passes. You should add a comment on why you force fail the test
 type FTWTestOverride struct {
-	Input     map[string]string `koanf:"input"`
+	Input     test.Input        `koanf:"input"`
 	Ignore    map[string]string `koanf:"ignore"`
 	ForcePass map[string]string `koanf:"forcepass"`
 	ForceFail map[string]string `koanf:"forcefail"`

--- a/test/types.go
+++ b/test/types.go
@@ -5,18 +5,18 @@ import "github.com/fzipi/go-ftw/ftwhttp"
 // Input represents the input request in a stage
 // The fields `Version`, `Method` and `URI` we want to explicitly now when they are set to ""
 type Input struct {
-	DestAddr       *string        `yaml:"dest_addr,omitempty"`
-	Port           *int           `yaml:"port,omitempty"`
-	Protocol       *string        `yaml:"protocol,omitempty"`
-	URI            *string        `yaml:"uri,omitempty"`
-	Version        *string        `yaml:"version,omitempty"`
-	Headers        ftwhttp.Header `yaml:"headers,omitempty"`
-	Method         *string        `yaml:"method,omitempty"`
-	Data           *string        `yaml:"data,omitempty"`
-	SaveCookie     bool           `yaml:"save_cookie,omitempty"`
-	StopMagic      bool           `yaml:"stop_magic"`
-	EncodedRequest string         `yaml:"encoded_request,omitempty"`
-	RAWRequest     string         `yaml:"raw_request,omitempty"`
+	DestAddr       *string        `yaml:"dest_addr,omitempty" koanf:"dest_addr,omitempty"`
+	Port           *int           `yaml:"port,omitempty" koanf:"port,omitempty"`
+	Protocol       *string        `yaml:"protocol,omitempty" koanf:"protocol,omitempty"`
+	URI            *string        `yaml:"uri,omitempty" koanf:"uri,omitempty"`
+	Version        *string        `yaml:"version,omitempty" koanf:"version,omitempty"`
+	Headers        ftwhttp.Header `yaml:"headers,omitempty" koanf:"headers,omitempty"`
+	Method         *string        `yaml:"method,omitempty" koanf:"method,omitempty"`
+	Data           *string        `yaml:"data,omitempty" koanf:"data,omitempty"`
+	SaveCookie     bool           `yaml:"save_cookie,omitempty" koanf:"save_cookie,omitempty"`
+	StopMagic      bool           `yaml:"stop_magic" koanf:"stop_magic,omitempty"`
+	EncodedRequest string         `yaml:"encoded_request,omitempty" koanf:"encoded_request,omitempty"`
+	RAWRequest     string         `yaml:"raw_request,omitempty" koanf:"raw_request,omitempty"`
 }
 
 // Output is the response expected from the test
@@ -28,6 +28,7 @@ type Output struct {
 	ExpectError      bool   `yaml:"expect_error,omitempty"`
 }
 
+// Stage is an individual test stage
 type Stage struct {
 	Input  Input  `yaml:"input"`
 	Output Output `yaml:"output"`


### PR DESCRIPTION
- "Host" header should be overridden with value of `dest_addr` override
  to ensure that requests will be accepted by targets.
- Added test for the above change.
- Converted `config.FTWConfig.TestOverride.Input` from `map[string]string`
  to `test.Input` for improved validation and better parsing

Co-authored-by: @dkegel-fastly

Replaces #61 
Fixes #60