### PR TITLE
fix: close previous connection before starting new one

### DIFF
--- a/ftwhttp/client.go
+++ b/ftwhttp/client.go
@@ -29,6 +29,12 @@ func NewClient() *Client {
 
 // NewConnection creates a new Connection based on a Destination
 func (c *Client) NewConnection(d Destination) error {
+	if c.Transport != nil {
+		if err := c.Transport.connection.Close(); err != nil {
+			return err
+		}
+	}
+
 	var err error
 	var netConn net.Conn
 


### PR DESCRIPTION
I randomly noticed this while debugging flakiness in my ftw tests. It didn't actually help 😂 But though it's still generally a good idea to close connections since otherwise I guess it is relying on GC.