### PR TITLE
feat: Use httpbin `/status` endpoint for markers

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -175,8 +175,11 @@ func RunStage(runContext *TestRunContext, ftwCheck *check.FTWCheck, testCase tes
 
 func markAndFlush(runContext *TestRunContext, dest *ftwhttp.Destination, stageID string) ([]byte, error) {
 	rline := &ftwhttp.RequestLine{
-		Method:  "GET",
-		URI:     "/",
+		Method: "GET",
+		// Use the `/status` endpoint of `httpbin` (http://httpbin.org), if possible,
+		// to minimize the amount of data transferred and in the log.
+		// `httpbin` is used by the CRS test setup.
+		URI:     "/status/200",
 		Version: "HTTP/1.1",
 	}
 


### PR DESCRIPTION
The root URI is not mapped by `httpbin`, so the repsponse will contain a large amount of HTML for the 404 page, which ends up in the log. We now use the `/status` endpoint to reduce the data transferred in each response to a marker request and the amount of data in the log.