### PR TITLE
fix: Reuse connection transport for marker requests

### DIFF
--- a/ftwhttp/client.go
+++ b/ftwhttp/client.go
@@ -36,36 +36,53 @@ func NewClient(config ClientConfig) *Client {
 
 // NewConnection creates a new Connection based on a Destination
 func (c *Client) NewConnection(d Destination) error {
-	if c.Transport != nil {
+	if c.Transport != nil && c.Transport.connection != nil {
 		if err := c.Transport.connection.Close(); err != nil {
 			return err
 		}
 	}
 
-	var err error
-	var netConn net.Conn
+	c.Transport = &Connection{
+		protocol:    d.Protocol,
+		readTimeout: c.config.ReadTimeout,
+		duration:    NewRoundTripTime(),
+	}
 
+	netConn, err := c.dial(d)
+	if err == nil {
+		c.Transport.connection = netConn
+	}
+
+	return err
+}
+
+// NewOrReusedConnection reuses an existing connection, or creates a new one
+// if no connection has been set up yet
+func (c *Client) NewOrReusedConnection(d Destination) error {
+	if c.Transport == nil {
+		return c.NewConnection(d)
+	}
+
+	netConn, err := c.dial(d)
+	if err == nil {
+		c.Transport.connection = netConn
+	}
+	return err
+
+}
+
+// dial tries to establish a connection
+func (c *Client) dial(d Destination) (net.Conn, error) {
 	hostPort := fmt.Sprintf("%s:%d", d.DestAddr, d.Port)
 
 	// Fatal error: dial tcp 127.0.0.1:80: connect: connection refused
 	// strings.HasSuffix(err.String(), "connection refused") {
 	if strings.ToLower(d.Protocol) == "https" {
 		// Commenting InsecureSkipVerify: true.
-		netConn, err = tls.DialWithDialer(&net.Dialer{Timeout: c.config.ConnectTimeout}, "tcp", hostPort, &tls.Config{MinVersion: tls.VersionTLS12})
-	} else {
-		netConn, err = net.DialTimeout("tcp", hostPort, c.config.ConnectTimeout)
+		return tls.DialWithDialer(&net.Dialer{Timeout: c.config.ConnectTimeout}, "tcp", hostPort, &tls.Config{MinVersion: tls.VersionTLS12})
 	}
 
-	if err == nil {
-		c.Transport = &Connection{
-			connection:  netConn,
-			protocol:    d.Protocol,
-			readTimeout: c.config.ReadTimeout,
-			duration:    NewRoundTripTime(),
-		}
-	}
-
-	return err
+	return net.DialTimeout("tcp", hostPort, c.config.ConnectTimeout)
 }
 
 // Do performs the http request roundtrip

--- a/ftwhttp/client_test.go
+++ b/ftwhttp/client_test.go
@@ -150,3 +150,78 @@ Some-file-test-here
 	}
 
 }
+
+func TestNewConnectionCreatesTransport(t *testing.T) {
+	c := NewClient(NewClientConfig())
+	if c.Transport != nil {
+		t.Errorf("Transport not expected to initialized yet")
+	}
+
+	server := testServer()
+	d, err := DestinationFromString(server.URL)
+	if err != nil {
+		t.Errorf("Failed to construct destination from test server")
+	}
+	if err := c.NewConnection(*d); err != nil {
+		t.Errorf("Failed to create new connection")
+	}
+	if c.Transport == nil {
+		t.Errorf("Transport expected to be initialized")
+	}
+	if c.Transport.connection == nil {
+		t.Errorf("Connection expected to be initialized")
+	}
+
+}
+
+func TestNewOrReusedConnectionCreatesTransport(t *testing.T) {
+	c := NewClient(NewClientConfig())
+	if c.Transport != nil {
+		t.Errorf("Transport not expected to initialized yet")
+	}
+
+	server := testServer()
+	d, err := DestinationFromString(server.URL)
+	if err != nil {
+		t.Errorf("Failed to construct destination from test server")
+	}
+	if err := c.NewOrReusedConnection(*d); err != nil {
+		t.Errorf("Failed to create new connection")
+	}
+	if c.Transport == nil {
+		t.Errorf("Transport expected to be initialized")
+	}
+	if c.Transport.connection == nil {
+		t.Errorf("Connection expected to be initialized")
+	}
+}
+
+func TestNewOrReusedConnectionReusesTransport(t *testing.T) {
+	c := NewClient(NewClientConfig())
+	if c.Transport != nil {
+		t.Errorf("Transport not expected to initialized yet")
+	}
+
+	server := testServer()
+	d, err := DestinationFromString(server.URL)
+	if err != nil {
+		t.Errorf("Failed to construct destination from test server")
+	}
+	if err := c.NewOrReusedConnection(*d); err != nil {
+		t.Errorf("Failed to create new connection")
+	}
+	if c.Transport == nil {
+		t.Errorf("Transport expected to be initialized")
+	}
+	if c.Transport.connection == nil {
+		t.Errorf("Connection expected to be initialized")
+	}
+
+	begin := c.Transport.duration.begin
+	if err := c.NewOrReusedConnection(*d); err != nil {
+		t.Errorf("Failed to reuse connection")
+	}
+	if c.Transport.duration.begin != begin {
+		t.Errorf("Transport must not be reinitialized when reusing connection")
+	}
+}

--- a/runner/run.go
+++ b/runner/run.go
@@ -195,7 +195,7 @@ func markAndFlush(runContext *TestRunContext, dest *ftwhttp.Destination, stageID
 	// 20 is a very conservative number. The web server should flush its
 	// buffer a lot earlier but we have absolutely no control over that.
 	for range [20]int{} {
-		err := runContext.Client.NewConnection(*dest)
+		err := runContext.Client.NewOrReusedConnection(*dest)
 		if err != nil {
 			return nil, fmt.Errorf("ftw/run: can't connect to destination %+v: %w", dest, err)
 		}


### PR DESCRIPTION
Marker requests would reset the `Transport` struct, thereby unintentionally resetting the round trip time.

- Add `NewOrReusedConnection` to allow connections to be reused
- Move dialling logic to separate method
- Make marker requests use `NewOrReusedConnection` instead of `NewConnection`

This is an alternative to #76. @fzipi you need to decide which one you want to keep.