### PR TITLE
Directly read HTTP response from connection instead of copying to byt…

### DIFF
--- a/ftwhttp/connection.go
+++ b/ftwhttp/connection.go
@@ -3,7 +3,6 @@ package ftwhttp
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"io"
 	"net"
@@ -65,25 +64,16 @@ func (c *Connection) send(data []byte) (int, error) {
 
 }
 
-func (c *Connection) receive() ([]byte, error) {
+func (c *Connection) receive() (io.Reader, error) {
 	log.Trace().Msg("ftw/http: receiving data")
-	var err error
-	var buf []byte
 
 	// We assume the response body can be handled in memory without problems
 	// That's why we use io.ReadAll
-	if err = c.connection.SetReadDeadline(time.Now().Add(c.readTimeout)); err == nil {
-		buf, err = io.ReadAll(c.connection)
+	if err := c.connection.SetReadDeadline(time.Now().Add(c.readTimeout)); err != nil {
+		return nil, err
 	}
 
-	if neterr, ok := err.(net.Error); ok && !neterr.Timeout() {
-		log.Error().Msgf("ftw/http: %s\n", err.Error())
-	} else {
-		err = nil
-	}
-	log.Trace().Msgf("ftw/http: received data - %q", buf)
-
-	return buf, err
+	return c.connection, nil
 }
 
 // Request will use all the inputs and send a raw http request to the destination
@@ -108,13 +98,12 @@ func (c *Connection) Request(request *Request) error {
 // Response reads the response sent by the WAF and return the corresponding struct
 // It leverages the go stdlib for reading and parsing the response
 func (c *Connection) Response() (*Response, error) {
-	data, err := c.receive()
+	r, err := c.receive()
 
 	if err != nil {
 		return nil, err
 	}
 
-	r := bytes.NewReader(data)
 	reader := *bufio.NewReader(r)
 
 	httpResponse, err := http.ReadResponse(&reader, nil)
@@ -122,7 +111,6 @@ func (c *Connection) Response() (*Response, error) {
 		return nil, err
 	}
 	response := Response{
-		RAW:    data,
 		Parsed: *httpResponse,
 	}
 	return &response, err

--- a/ftwhttp/types.go
+++ b/ftwhttp/types.go
@@ -71,5 +71,6 @@ type Request struct {
 
 // Response represents the http response received from the server/waf
 type Response struct {
+	RAW    []byte
 	Parsed http.Response
 }

--- a/ftwhttp/types.go
+++ b/ftwhttp/types.go
@@ -71,6 +71,5 @@ type Request struct {
 
 // Response represents the http response received from the server/waf
 type Response struct {
-	RAW    []byte
 	Parsed http.Response
 }


### PR DESCRIPTION
…es first.

Currently, there are cases where go-ftw will block until read timeout even after getting a whole HTTP response. I'm not exactly sure what causes it (I notice in my tests when Envoy returns an error response directly without proxying it seems to happen), but it sort of makes sense - usually you'd expect to need to parse the HTTP response to know when it's done since a connection is just otherwise a stream of bytes, so I'm actually less sure why it wouldn't always be blocking until read timeout.

This changes to parse straight into the HTTP response so HTTP semantics correctly let the response parsing finish when it's done, now I see some tests that always passed after 1s taking the expected several ms.